### PR TITLE
updates workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,7 @@ jobs:
           FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
           EDGE_PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
           EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
-          EDGE_CLIENT_SECRET: ${{ secrets.EDGE_CLIENT_SECRET }}
-          EDGE_ACCESS_TOKEN_URL: ${{ secrets.EDGE_ACCESS_TOKEN_URL }}
+          EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
 
       - name: 发布到应用商店
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yml` file to modify the secrets used for the Edge browser release process. The changes replace the use of `EDGE_CLIENT_SECRET` and `EDGE_ACCESS_TOKEN_URL` with a new `EDGE_API_KEY`.

Secrets update for Edge release process:

* Replaced `EDGE_CLIENT_SECRET` and `EDGE_ACCESS_TOKEN_URL` with `EDGE_API_KEY` in the workflow configuration. This change was applied in two locations within the `jobs:` section of the file. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L62-R62) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L83-R82)